### PR TITLE
21 11

### DIFF
--- a/assets/root-configuration-flexbox.nix
+++ b/assets/root-configuration-flexbox.nix
@@ -27,25 +27,25 @@ in
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  # Switch to 5.13.x kernel because hardware is new
-  #boot.kernelPackages = pkgs.linuxPackages_5_13;
+  # Switch to a newer kernel (>5.13) for audio and GPU support
+  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   # Fix audio
-  # boot.kernelPatches = [
-  #   {
-  #     name = "enable-soundwire-drivers";
-  #     patch = null;
-  #     extraConfig = ''
-  #       SND_SOC_INTEL_USER_FRIENDLY_LONG_NAMES y
-  #       SND_SOC_INTEL_SOUNDWIRE_SOF_MACH m
-  #       SND_SOC_RT1308 m
-  #     '';
-  #     ignoreConfigErrors = true;
-  #   }
-  # ];
-  # boot.extraModprobeConfig = ''
-  #   options snd-hda-intel model=auto, enable_msi=1
-  # '';
+  boot.kernelPatches = [
+    {
+      name = "enable-soundwire-drivers";
+      patch = null;
+      extraConfig = ''
+        SND_SOC_INTEL_USER_FRIENDLY_LONG_NAMES y
+        SND_SOC_INTEL_SOUNDWIRE_SOF_MACH m
+        SND_SOC_RT1308 m
+      '';
+      ignoreConfigErrors = true;
+    }
+  ];
+  boot.extraModprobeConfig = ''
+    options snd-hda-intel model=auto, enable_msi=1
+  '';
 
   # GPU
   environment.systemPackages = [ nvidia-offload ];

--- a/assets/root-configuration-flexbox.nix
+++ b/assets/root-configuration-flexbox.nix
@@ -28,21 +28,21 @@ in
   boot.loader.efi.canTouchEfiVariables = true;
 
   # Switch to 5.13.x kernel because hardware is new
-  boot.kernelPackages = pkgs.linuxPackages_5_13;
+  #boot.kernelPackages = pkgs.linuxPackages_5_13;
 
   # Fix audio
-  boot.kernelPatches = [
-    {
-      name = "enable-soundwire-drivers";
-      patch = null;
-      extraConfig = ''
-        SND_SOC_INTEL_USER_FRIENDLY_LONG_NAMES y
-        SND_SOC_INTEL_SOUNDWIRE_SOF_MACH m
-        SND_SOC_RT1308 m
-      '';
-      ignoreConfigErrors = true;
-    }
-  ];
+  # boot.kernelPatches = [
+  #   {
+  #     name = "enable-soundwire-drivers";
+  #     patch = null;
+  #     extraConfig = ''
+  #       SND_SOC_INTEL_USER_FRIENDLY_LONG_NAMES y
+  #       SND_SOC_INTEL_SOUNDWIRE_SOF_MACH m
+  #       SND_SOC_RT1308 m
+  #     '';
+  #     ignoreConfigErrors = true;
+  #   }
+  # ];
   # boot.extraModprobeConfig = ''
   #   options snd-hda-intel model=auto, enable_msi=1
   # '';

--- a/dotfiles/coc-settings.json
+++ b/dotfiles/coc-settings.json
@@ -28,5 +28,7 @@
   "flutter.lsp.initialization.closingLabels": true,
   "rust-analyzer.updates.prompt": false,
   "rust-analyzer.checkOnSave.command": "clippy",
-  "rust-analyzer.cargo.runBuildScripts": true
+  "rust-analyzer.cargo.runBuildScripts": true,
+  "rust-analyzer.procMacro.enable": true,
+  "rust-analyzer.diagnostics.disabled": ["unresolved-proc-macro"]
 }

--- a/home.nix
+++ b/home.nix
@@ -47,6 +47,7 @@ in
       ".ideavimrc".source = ./dotfiles/ideavimrc;
 
       # Less
+      # TODO: This might now be supported natively, see home-manager news
       ".lesskey" = {
         onChange = "lesskey";
         source = ./dotfiles/lesskey;
@@ -133,10 +134,10 @@ in
 
     firefox = {
       enable = true;
-      extensions = with nur.repos.rycee.firefox-addons; [
-        lastpass-password-manager
-        privacy-badger
-      ];
+      # extensions = with nur.repos.rycee.firefox-addons; [
+      #   lastpass-password-manager
+      #   privacy-badger
+      # ];
       profiles = {
         main = { };
       };

--- a/home.nix
+++ b/home.nix
@@ -130,7 +130,7 @@ in
     };
 
     direnv.enable = true;
-    direnv.enableNixDirenvIntegration = true;
+    direnv.nix-direnv.enable = true;
 
     firefox = {
       enable = true;

--- a/home/i3status-rust.nix
+++ b/home/i3status-rust.nix
@@ -38,6 +38,7 @@ let
         "alsa_output.usb-Apple__Inc._USB-C_to_3.5mm_Headphone_Jack_Adapter_DWH84440324JKLTA7-00.analog-stereo" = "";
         "bluez_sink.14_3F_A6_28_DC_51.a2dp_sink" = "";
       };
+      headphones_indicator = true;
     }
   ];
 

--- a/home/i3status-rust.nix
+++ b/home/i3status-rust.nix
@@ -33,7 +33,7 @@ let
       format = "{output_name} {volume}";
       on_click = "pavucontrol --tab=3";
       mappings = {
-        "alsa_output.pci-0000_00_1f.3-platform-sof_sdw.HiFi__hw_sofsoundwire_2__sink" = "";
+        "alsa_output.pci-0000_00_1f.3-platform-sof_sdw.HiFi___ucm0003.hw_sofsoundwire_2__sink" = "";
         "alsa_output.pci-0000_00_1f.3-platform-sof_sdw.HiFi__hw_sofsoundwire__sink" = "";
         "alsa_output.usb-Apple__Inc._USB-C_to_3.5mm_Headphone_Jack_Adapter_DWH84440324JKLTA7-00.analog-stereo" = "";
         "bluez_sink.14_3F_A6_28_DC_51.a2dp_sink" = "";

--- a/home/rofi.nix
+++ b/home/rofi.nix
@@ -15,40 +15,42 @@ in
       columns = 2;
     };
 
-    colors = {
-      rows = rec {
-        normal = {
-          background = color1;
-          foreground = color3;
-          backgroundAlt = color1;
-          highlight = {
-            background = color1;
-            foreground = color2;
-          };
-        };
-        active = normal;
-        urgent = normal;
-      };
+    # theme = {
+    #   colors = {
+    #     rows = rec {
+    #       normal = {
+    #         background = color1;
+    #         foreground = color3;
+    #         backgroundAlt = color1;
+    #         highlight = {
+    #           background = color1;
+    #           foreground = color2;
+    #         };
+    #       };
+    #       active = normal;
+    #       urgent = normal;
+    #     };
 
-      window = {
-        background = color1;
-        border = color2;
-        separator = color2;
-      };
-    };
+    #     window = {
+    #       background = color1;
+    #       border = color2;
+    #       separator = color2;
+    #     };
+    #   };
+
+    #   separator = "solid";
+
+    #   scrollbar = false;
+
+    #   padding = 5;
+
+    #   lines = 5;
+    # };
 
     font = "Fira Code 12";
-
-    lines = 5;
 
     package = pkgs.rofi.override {
       plugins = [ pkgs.rofi-calc pkgs.rofi-emoji ];
     };
-
-    padding = 5;
-
-    scrollbar = false;
-
-    separator = "solid";
   };
 }

--- a/home/xsession/i3.nix
+++ b/home/xsession/i3.nix
@@ -298,6 +298,9 @@ in
       # Run KBDD (XKB Daemon for per-window keyboard layout switching)
       { command = "kbdd"; notification = false; }
 
+      # Switch keybboard layout (since the NixOS option no longer works in 21.11)
+      { command = ''setxkbmap -option "grp:ctrls_toggle,eurosign:e,caps:escape_shifted_capslock,terminate:ctrl_alt_bksp"''; notification = false; }
+
     ];
 
     terminal = "alacritty";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -31,7 +31,6 @@ in
       "nixos-config=/etc/nixos/configuration.nix"
       "/nix/var/nix/profiles/per-user/root/channels"
       "nixpkgs-unstable=${sources.nixpkgs-unstable}"
-      "nixos-unstable=${sources.nixos-unstable}"
       "nur=${sources.NUR}"
     ];
   };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://rycee.gitlab.io/home-manager/",
         "owner": "rycee",
         "repo": "home-manager",
-        "rev": "95da56b783e4ccc8ded71137e4add780b239dd46",
-        "sha256": "07gfm98svx67g6mfqx1inh0k0rc60v2pqr6wp23wwrk2zcx6lcwq",
+        "rev": "829e89a16f4f96428d1b94e68d4c06107b5491c0",
+        "sha256": "1jgzwhlpxi204nl85dpdh6acwzqzznf4rpz9lnw7mpnmzb1lxgkp",
         "type": "tarball",
-        "url": "https://github.com/rycee/home-manager/archive/95da56b783e4ccc8ded71137e4add780b239dd46.tar.gz",
+        "url": "https://github.com/rycee/home-manager/archive/829e89a16f4f96428d1b94e68d4c06107b5491c0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-unstable": {
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbfb79400a08bf754e32b4d4fc3f7d8f8055cf94",
-        "sha256": "0pgyx1l1gj33g5i9kwjar7dc3sal2g14mhfljcajj8bqzzrbc3za",
+        "rev": "bc5d68306b40b8522ffb69ba6cff91898c2fbbff",
+        "sha256": "0c5qjrmh1k2zr15x2i9cp6n1r2pvrlk7hdyfvrwzpk963gc9ssmz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fbfb79400a08bf754e32b4d4fc3f7d8f8055cf94.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/bc5d68306b40b8522ffb69ba6cff91898c2fbbff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-mozilla": {
@@ -65,10 +65,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3a23d9599b0a82e333ad91db2cdc479313ce154",
-        "sha256": "05xmgrrnw6j39lh3d48kg064z510i0w5vvrm1s5cdwhdc2fkspjq",
+        "rev": "f225322e3bea8638304adfcf415cd11de99f2208",
+        "sha256": "1cbl7w81h2m4as15z094jkcrgg2mdi2wnkzg2dhd6080vgic11vy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a3a23d9599b0a82e333ad91db2cdc479313ce154.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f225322e3bea8638304adfcf415cd11de99f2208.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-vimplugins-coc-flutter": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f225322e3bea8638304adfcf415cd11de99f2208",
-        "sha256": "1cbl7w81h2m4as15z094jkcrgg2mdi2wnkzg2dhd6080vgic11vy",
+        "rev": "7ac6901f5e3038d59d3e2576af445fe418291dd8",
+        "sha256": "0p2him37s2p97ya46nrz515wrs5x8p7my7hz9bc1n11dfavhz05h",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f225322e3bea8638304adfcf415cd11de99f2208.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7ac6901f5e3038d59d3e2576af445fe418291dd8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-vimplugins-coc-flutter": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,18 +23,6 @@
         "url": "https://github.com/rycee/home-manager/archive/829e89a16f4f96428d1b94e68d4c06107b5491c0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "nixos-unstable": {
-        "branch": "nixos-unstable",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
-        "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bc5d68306b40b8522ffb69ba6cff91898c2fbbff",
-        "sha256": "0c5qjrmh1k2zr15x2i9cp6n1r2pvrlk7hdyfvrwzpk963gc9ssmz",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/bc5d68306b40b8522ffb69ba6cff91898c2fbbff.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs-mozilla": {
         "branch": "master",
         "description": "mozilla related nixpkgs (extends nixos/nixpkgs repo)",

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -93,6 +93,7 @@ let
       nixpkgs-unstable.nixpkgs-review
       pkgs.nix-index # Provides nix-locate, see https://github.com/bennofs/nix-index
       pkgs.nodejs # For coc.nvim
+      pkgs.nvtop
       pkgs.okular
       pkgs.onboard # On screen keyboard
       pkgs.p7zip

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -79,7 +79,7 @@ let
       pkgs.lm_sensors
       pkgs.lsof
       pkgs.lz4 # compression
-      nixos-unstable.manix
+      #nixos-unstable.manix # TODO: Reactivate
       nixpkgs-unstable.materialize
       pkgs.megacmd
       nixpkgs-unstable.minikube

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -130,7 +130,9 @@ let
       nixpkgs-unstable.tdesktop # Telegram
       pkgs.tlaplusToolbox
       pkgs.tldr
-      nixpkgs-unstable.todoist-electron
+      # Monkey-patch needed for current todoist-electron: https://github.com/NixOS/nixpkgs/issues/147319
+      (nixpkgs-unstable.todoist-electron.override
+        { electron = nixpkgs-unstable.electron_15; })
       pkgs.trash-cli
       pkgs.tree
       pkgs.unzip

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -50,7 +50,6 @@ let
       pkgs.gcr # Gnome crypto stuff for gnome-keyring
       pkgs.gimp
       pkgs.github-cli
-      pkgs.gitkraken
       pkgs.gmailctl
       pkgs.gomatrix # The Matrix
       pkgs.google-chrome
@@ -135,7 +134,7 @@ let
       pkgs.tree
       pkgs.unzip
       pkgs.usbutils # Provides lsusb
-      variety
+      #variety # TODO: Reactivate
       pkgs.v4l-utils # Video4Linux2 -> configuring webcam
       pkgs.virt-manager
       pkgs.vlc

--- a/system/default.nix
+++ b/system/default.nix
@@ -67,7 +67,7 @@
   programs.sysdig.enable = true;
 
   # Steam
-  programs.steam.enable = true;
+  #programs.steam.enable = true; # TODO: Re-enable
 
   # Flatpack service
   # https://flatpak.org/setup/NixOS/

--- a/system/keyboard.nix
+++ b/system/keyboard.nix
@@ -4,6 +4,7 @@
   # writes to /etc/X11/xorg.conf.d
   services.xserver = {
     layout = "us,de,ua";
-    xkbOptions = "grp:ctrls_toggle,eurosign:e,caps:escape_shifted_capslock,terminate:ctrl_alt_bksp";
+    # FIXME: Stopped working in 21.11, now setting manually via i3 startup
+    #xkbOptions = "grp:ctrls_toggle,eurosign:e,caps:escape_shifted_capslock,terminate:ctrl_alt_bksp";
   };
 }

--- a/system/virtualisation.nix
+++ b/system/virtualisation.nix
@@ -5,7 +5,8 @@
 
   virtualisation.libvirtd.enable = true;
   # Forward USB devices from unprivileged user for use by Spice USB Forwarding (via virt-manager)
-  security.wrappers.spice-client-glib-usb-acl-helper.source = "${pkgs.spice-gtk}/bin/spice-client-glib-usb-acl-helper";
+  # TODO: The security.wrappers option now requires to always specify an owner, group and whether the setuid/setgid bit should be set. This is motivated by the fact that before NixOS 21.11, specifying either setuid or setgid but not owner/group resulted in wrappers owned by nobody/nogroup, which is unsafe.
+  #security.wrappers.spice-client-glib-usb-acl-helper.source = "${pkgs.spice-gtk}/bin/spice-client-glib-usb-acl-helper";
 
   # TODO: This is insecure
   # See https://nixos.wiki/wiki/Docker


### PR DESCRIPTION
- Disable broken proc-macro rust-analyzer warnings
- Nixos 21.11 upgrade
- Switch to linux 5.15.4
- Update nixpkgs-unstable
- Drop nixos-unstable dependency
- Set xkbOptions via i3 startup since broken in NixOS
- Add nvtop
- Monkey-patch todoist-electron
- Fix SOF internal speaker mapping
- Use new automatic sound block setting
- Update nix direnv integration setting format
